### PR TITLE
Uncomment XML config line in Drawings and bug fix in Table.js

### DIFF
--- a/Excel/Drawings.js
+++ b/Excel/Drawings.js
@@ -25,7 +25,7 @@ define(['underscore', './RelationshipManager', './util'], function (_, Relations
         toXML: function () {
             var doc = util.createXmlDoc(util.schemas.spreadsheetDrawing, 'xdr:wsDr');
             var drawings = doc.documentElement;
-//            drawings.setAttribute('xmlns:xdr', util.schemas.spreadsheetDrawing);
+            drawings.setAttribute('xmlns:xdr', util.schemas.spreadsheetDrawing);
             drawings.setAttribute('xmlns:a', util.schemas.drawing);
             
             for(var i = 0, l = this.drawings.length; i < l; i++) {

--- a/Excel/Table.js
+++ b/Excel/Table.js
@@ -121,7 +121,7 @@ define(['underscore', './util'], function (_, util) {
 			
             table.appendChild(this.exportTableColumns(doc));
             table.appendChild(this.exportTableStyleInfo(doc));
-            return table;
+            return doc;
         },
 		
         exportTableColumns: function (doc) {


### PR DESCRIPTION
FIX:
- The 'toXML' function in Table.js was returning the wrong variable. It should return the 'doc' variable. Fixed in this commit.
- The uncommented line for an XML attribute in Drawings.js is required to generate an XLSX with images properly. Fixed in this commit.
