### PR TITLE
Improve usage with Bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ buildtools/index.js
 build
 node_modules
 jszip.js
+bower_components

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
             }
         }
     };
-    
+
     var files = grunt.file.expand({
         cwd: './dist',
         filter: function (src) {
@@ -56,6 +56,22 @@ module.exports = function(grunt) {
                     },
                     out: "dist/<%= pkg.name %>.dist.js"
                 }, compileOptions)
+            },
+            nodep: {
+                options: _.defaults({
+                    wrap: {
+                        startFile: [
+                            './buildtools/start.js',
+                            './node_modules/almond/almond.js',
+                            './buildtools/defined.js'
+                        ],
+                        endFile: [
+                            './buildtools/end.js'
+                        ]
+                    },
+                    exclude: ["underscore", "JSZip"],
+                    out: "dist/<%= pkg.name %>.nodep.js"
+                }, compileOptions)
             }
         },
         copy: {
@@ -73,7 +89,8 @@ module.exports = function(grunt) {
             optimize: {
                 files: {
                     'dist/<%= pkg.name %>.compiled.min.js': ['dist/<%= pkg.name %>.compiled.js'],
-                    'dist/<%= pkg.name %>.dist.min.js': ['dist/<%= pkg.name %>.dist.js']
+                    'dist/<%= pkg.name %>.dist.min.js': ['dist/<%= pkg.name %>.dist.js'],
+                    'dist/<%= pkg.name %>.nodep.min.js': ['dist/<%= pkg.name %>.nodep.js']
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Combine & uglify:
 
 Distributables
 ---------------
-excel-builder.compiled.js -> All files in the EB package + Underscore
+excel-builder.compiled.js -> All files in the EB package + Underscore + jszip
 
-excel-builder.dist.js -> All files in the EB package + Underscore, with no need for external AMD provider (Web worker will not function in this build).
+excel-builder.dist.js -> All files in the EB package + Underscore + jszip, with no need for external AMD provider (Web worker will not function in this build).
+
+excel-builder.nodep.js -> All files in the EB package, with no need for external AMD provider (Web worker will not function in this build).
 
 Contributing
 -------------

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "excel-builder",
+  "main": "dist/excel-builder.dist.js",
+  "version": "1.0.0",
+  "homepage": "https://github.com/stephenliberty/excel-builder.js",
+  "authors": [
+    "Stephen Liberty"
+  ],
+  "license": "GPLv3",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "spec",
+    "tests"
+  ],
+  "dependencies": {
+    "underscore": "~1.6.0",
+    "jszip": "~2.0.0"
+  }
+}

--- a/buildtools/defined.js
+++ b/buildtools/defined.js
@@ -1,0 +1,3 @@
+requirejs._defined.underscore = window._;
+requirejs._defined.JSZip = window.JSZip;
+


### PR DESCRIPTION
- add bower.json
- add additional build that does not contain underscore and jszip

When using dist it is not possible to use an already loaded underscore or jszip