### PR TITLE
Fix #34 (LibreOffice styling)

### DIFF
--- a/Excel/StyleSheet.js
+++ b/Excel/StyleSheet.js
@@ -370,8 +370,18 @@ define(['underscore', './util'], function (_, util) {
             while(a--) {
                 xf.setAttribute(attributes[a], styleInstructions[attributes[a]]);
             }
+
+            if(styleInstructions.alignment) {
+                xf.setAttribute('applyAlignment', '1');
+            }
+            if(styleInstructions.borderId) {
+                xf.setAttribute('applyBorder', '1');
+            }
             if(styleInstructions.fillId) {
                 xf.setAttribute('applyFill', '1');
+            }
+            if(styleInstructions.fontId) {
+                xf.setAttribute('applyFont', '1');
             }
             return xf;
         },


### PR DESCRIPTION
When the `apply*` parameters are missing, LibreOffice reasonably assumes false, as any implementer of the spec (Ecma Office Open Part 1, §18.8.45 / page 1791) would do.
Microsoft Excel seems to default to true, thereby underscoring that the apply* properties are misconstructed in the first place.
We can simply set always set `apply*`.
