### PR TITLE
Set xfId on xf elements when numFmt used is being

### DIFF
--- a/Excel/StyleSheet.js
+++ b/Excel/StyleSheet.js
@@ -373,6 +373,9 @@ define(['underscore', './util'], function (_, util) {
             if(styleInstructions.fillId) {
                 xf.setAttribute('applyFill', '1');
             }
+            if((styleInstructions.numFmtId !== undefined) && (styleInstructions.xfId === undefined)) {
+                xf.setAttribute('xfId', '0');
+            }
             return xf;
         },
         


### PR DESCRIPTION
This is totally brain-dead and undocumented, but on LibreOffice 4.4.4.3 on debian amd64, without an xfId numFmtId is ignored.