### PR TITLE
Add xml:space attribute to untrimmed strings

### DIFF
--- a/Excel/SharedStrings.js
+++ b/Excel/SharedStrings.js
@@ -42,6 +42,9 @@ define(['underscore', './util'], function (_, util) {
             
             while (l--) {
                 var clone = template.cloneNode(true);
+                if(strings[l] && (strings[l] !== strings[l].trim())){
+                    clone.firstChild.setAttribute('xml:space', 'preserve');
+                }
                 clone.firstChild.firstChild.nodeValue = strings[l];
                 sharedStringTable.appendChild(clone);
             }


### PR DESCRIPTION
By default, when a string with leading or trailing whitespace is entered into an Excel worksheet, Excel adds the xml:space = "preserve" attribute to the corresponding \<t\> tag in SharedStrings.xml. When this is not present, the space remains in SharedStrings.xml, but Excel does not display the leading/trailing whitespace.

This change would add the xml:space = "preserve" attribute to strings with leading or trailing whitespace, in line with the default Excel behavior. If a user would like to trim values, he/she can do so before inserting the strings into the worksheet.