### PR TITLE
Downgrade jszip in bower to 2.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,6 @@
   ],
   "dependencies": {
     "lodash": "~4.11.1",
-    "jszip": "~3.0.0"
+    "jszip": "~2.6.0"
   }
 }


### PR DESCRIPTION
generate() has been deprecated and can no longer be used in jszip 3.0 and [needs to be replaced with new methods](https://stuk.github.io/jszip/documentation/upgrade_guide.html). 
