### PR TITLE
Allow spaces to be placed in SharedStrings file

### DIFF
--- a/src/Excel/SharedStrings.js
+++ b/src/Excel/SharedStrings.js
@@ -45,6 +45,9 @@ _.extend(sharedStrings.prototype, {
 
         while (l--) {
             var clone = template.cloneNode(true);
+            if (strings[l] && strings[l].match(/\s+/)) {
+                clone.firstChild.setAttribute('xml:space', 'preserve');
+            }
             clone.firstChild.firstChild.nodeValue = strings[l];
             sharedStringTable.appendChild(clone);
         }


### PR DESCRIPTION
If a shared string is a space character, it can't be placed without specifying `xml:space='preserve'`