### PR TITLE
Fix duplicate definition of setPageOrientation method.

### DIFF
--- a/src/Excel/Worksheet.js
+++ b/src/Excel/Worksheet.js
@@ -517,18 +517,6 @@ var SheetView = require('./SheetView');
                 ]));
             }
         },
-    
-        /**
-         * http://www.schemacentral.com/sc/ooxml/t-ssml_ST_Orientation.html
-         * 
-         * Can be one of 'portrait' or 'landscape'.
-         * 
-         * @param {String} orientation
-         * @returns {undefined}
-         */
-        setPageOrientation: function (orientation) {
-            this._orientation = orientation;
-        },
         
         /**
          * Set page details in inches.


### PR DESCRIPTION
This change simply removes a dupliate defintion of the `setPageOrientation` method on the `Worksheet` object.  The duplicate definition causes failure to load in IE11 strict mode.